### PR TITLE
Solve an error when using with copilot.lua

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -20,7 +20,7 @@ M.setup = function(options)
   --  Loop through merged table and generate commands based on keys.
   for key, value in pairs(prompts) do
     utils.create_cmd('CopilotChat' .. key, function()
-      vim.cmd('CopilotChat ' .. value)
+      vim.cmd('CopilotChatInner ' .. value)
     end, { nargs = '*', range = true })
   end
 end

--- a/rplugin/python3/copilot-plugin.py
+++ b/rplugin/python3/copilot-plugin.py
@@ -30,7 +30,7 @@ class CopilotChatPlugin(object):
             self.nvim.out_write("Successfully authenticated with Copilot\n")
         self.copilot.authenticate()
 
-    @pynvim.command("CopilotChat", nargs="1")
+    @pynvim.command("CopilotChatInner", nargs="1")
     def copilotChat(self, args: list[str]):
         if self.copilot.github_token is None:
             self.nvim.out_write("Please authenticate with Copilot first\n")


### PR DESCRIPTION
## WHAT

Changed the inner pynvim command from "CopilotChat" to "CopilotChatInner"

## WHY

Using this plugin with copilot.lua (not copilot.vim) the vim commands conflicted with each other always throwing error 464: "Ambiguous use of user-defined command". This removes this ambiguity.



## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause ecxisting functionality to change)

## Checklist:


- [ ] Linter
- [ ] Tests
- [ ] Review comments
- [ ] Security
