### PR TITLE
fix: Close spinner if the buffer does not exist

### DIFF
--- a/lua/CopilotChat/spinner.lua
+++ b/lua/CopilotChat/spinner.lua
@@ -58,6 +58,11 @@ function M.show(position)
     0,
     100,
     vim.schedule_wrap(function()
+      if vim.fn.bufexists(spinner_buf) == 0 then
+        -- Hide the spinner if the buffer does not exist
+        M.hide()
+        return
+      end
       vim.api.nvim_buf_set_lines(
         spinner_buf,
         0,


### PR DESCRIPTION
## WHAT

Hide the spinner if the buffer it's targeting does not exist.

<!-- Links to task(s): -->

<!-- Link to testing: -->

<!-- Links to documentation or discussion -->

## WHY
If you close the vertical split before it's done generating you're going to get spammed with errors because the buffer it's trying to access is invalid.

## HOW
Use builtin vim functions to check if the buffer that's being targeted is valid, if it isn't hide the spinner.

## Screenshots (if appropriate):

<!-- Attach a screen shot if ui change -->
<!-- or attach a gif if workflow has changed -->

## Types of changes

<!-- Types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] Linter
- [ ] Tests
- [ ] Review comments
- [x] Security

_Note_: I'm very very new to lua. 